### PR TITLE
Corrección del tipo de apiResponse a JsonNode.

### DIFF
--- a/src/main/java/com/ingsoft/tfi/controllers/ClinicaRestController.java
+++ b/src/main/java/com/ingsoft/tfi/controllers/ClinicaRestController.java
@@ -39,7 +39,7 @@ public class ClinicaRestController {
 
 
     @PostMapping("/paciente/{dniPaciente}/diagnostico/{idDiagnostico}/evolucion")
-    public ResponseEntity<ApiResponse<?>> agregarEvolucion(@PathVariable String dniPaciente,
+    public ResponseEntity<ApiResponse<JsonNode>> agregarEvolucion(@PathVariable String dniPaciente,
                                              @PathVariable Long idDiagnostico,
                                              @RequestBody JsonNode json){
 
@@ -57,9 +57,10 @@ public class ClinicaRestController {
 
             return new ResponseEntity<>(response, HttpStatus.CREATED);
         } catch (Exception e) {
-            ApiResponse<Void> response = new ApiResponse<>(HttpStatus.BAD_REQUEST.value(),
-                    "Error al agregar la evolución: " + e.getMessage(),
-                    null);
+            ApiResponse<JsonNode> response = new ApiResponse<>(HttpStatus.BAD_REQUEST.value(),
+                    "Error al agregar la evolución",
+                    JsonParser.exJsonNode(e.getMessage())
+            );
 
             return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/com/ingsoft/tfi/controllers/JsonParser.java
+++ b/src/main/java/com/ingsoft/tfi/controllers/JsonParser.java
@@ -3,17 +3,13 @@ package com.ingsoft.tfi.controllers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.ingsoft.tfi.models.*;
-import jdk.jshell.Diag;
-import org.springframework.cache.support.NullValue;
 
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -25,6 +21,14 @@ public class JsonParser {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    public static JsonNode exJsonNode(String exception) {
+        ObjectNode json = mapper.createObjectNode();
+
+        json.put("error", exception);
+
+        return json;
+    }
+;
     public static String informeDesdeJson(JsonNode json){
         return json.get("informe").asText("");
     }
@@ -72,7 +76,7 @@ public class JsonParser {
     }
 
     public static JsonNode pacienteAJson(PacienteModel paciente){
-        ObjectNode json= mapper.createObjectNode();
+        ObjectNode json = mapper.createObjectNode();
 
         json.put("nombre" , paciente.getNombre());
         json.put("apellido" , paciente.getApellido());


### PR DESCRIPTION
Basicamente hice que el tipo de ApiResponse sea JsonNode.

Hay dos formas en que lo podemos hacer:

1. Devolviendo el campo "data" como un nodo de JsonNode vacío.

Ejemplo:
`{
    "status": 400,
    "message": "Error al agregar la evolución: Cannot invoke \"com.fasterxml.jackson.databind.JsonNode.asText(String)\" because the return value of \"com.fasterxml.jackson.databind.JsonNode.get(String)\" is null",
    "data": {}
}`

2. Devolver en el campo "data" un nodo que contenga el error. (La implementada en este PR)

Ejemplo:
`{
    "status": 400,
    "message": "Error al agregar la evolución",
    "data": {
        "error": "Cannot invoke \"com.fasterxml.jackson.databind.JsonNode.asText(String)\" because the return value of \"com.fasterxml.jackson.databind.JsonNode.get(String)\" is null"
    }
}`

Espero su cooperación revisando y debatiendo cual es la opción más adecuada.

Saludos.