### PR TITLE
Corrección Tipo de dato de Interface y modelo de medicamento a Long

### DIFF
--- a/src/main/java/com/ingsoft/tfi/models/MedicamentoModel.java
+++ b/src/main/java/com/ingsoft/tfi/models/MedicamentoModel.java
@@ -9,7 +9,7 @@ public class MedicamentoModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id_medicamento;
+    private Long id_medicamento;
 
     @Column
     private String nombreComercial;
@@ -28,11 +28,11 @@ public class MedicamentoModel {
 
     public MedicamentoModel(){}
 
-    public int getId_medicamento() {
+    public Long getId_medicamento() {
         return id_medicamento;
     }
 
-    public void setId_medicamento(int id_medicamento) {
+    public void setId_medicamento(Long id_medicamento) {
         this.id_medicamento = id_medicamento;
     }
 

--- a/src/main/java/com/ingsoft/tfi/repositories/IRepositorioMedicamento.java
+++ b/src/main/java/com/ingsoft/tfi/repositories/IRepositorioMedicamento.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 @Repository
 public interface IRepositorioMedicamento extends JpaRepository<MedicamentoModel, Long> {
-    Optional<MedicamentoModel> findById(Integer Id);
+    Optional<MedicamentoModel> findById(Long Id);
 }

--- a/src/main/java/com/ingsoft/tfi/services/MedicamentoService.java
+++ b/src/main/java/com/ingsoft/tfi/services/MedicamentoService.java
@@ -13,7 +13,7 @@ public class MedicamentoService {
    // @Autowired
     IRepositorioMedicamento repositorioMedicamento;
 
-    public Optional<MedicamentoModel> buscarMedicamento(Integer Id){
+    public Optional<MedicamentoModel> buscarMedicamento(Long Id){
         return repositorioMedicamento.findById(Id);
     }
 


### PR DESCRIPTION
Se corrigió el tipo de dato de la interfaz y del modelo de medicamento a long

Se tendrá que modificar en la Base de datos, es probable que de error por ser el id de medicamento autoincremental

podes probar estos scripts para armarlo:
`ALTER TABLE receta_digital_detalle DROP FOREIGN KEY id_medicamento;
ALTER TABLE medicamento MODIFY COLUMN id_medicamento BIGINT NOT NULL AUTO_INCREMENT;
ALTER TABLE receta_digital_detalle ADD CONSTRAINT FKniiqemmuqboqqdwcg9xypdax1 FOREIGN KEY (id_medicamento) REFERENCES medicamento(id_medicamento);`

Lo que hice yo para armarlo es:
ejecutar la querys para que se tire errror
en la tabla de receta digital detalle cambiarlo a bigint
por alguna razón se cambio solo en el de medicamento
y luego ejecutar la sentencia del constrain ese